### PR TITLE
Fix image helpers to use local OpenCV instance

### DIFF
--- a/js/modules/image-helpers.js
+++ b/js/modules/image-helpers.js
@@ -1,4 +1,5 @@
 // https://github.com/justadudewhohacks/opencv-electron/blob/master/plain-js/app/image-helpers.js
+const cv = require('opencv4nodejs');
 const pngPrefix = 'data:image/jpeg;base64,';
 const jpgPrefix = 'data:image/png;base64,';
 


### PR DESCRIPTION
## Summary
- ensure image helper utilities explicitly import OpenCV

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840978520d4832b85cd6bd3acb22724