### PR TITLE
Fix Node import issues

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,7 @@ import {MDCRipple} from '@material/ripple';
 import {MDCSnackbar} from '@material/snackbar';
 import { saveAs } from 'file-saver';
 const remote = window.require('electron').remote;
+const fs = require('fs');
 
 // Set window title
 var pjson = require('../package.json');

--- a/js/modules/dendrogram.js
+++ b/js/modules/dendrogram.js
@@ -5,6 +5,7 @@ const ih = require('../../js/modules/image-helpers.js');
 const cv = require('opencv4nodejs');
 const props = require('../../js/modules/properties.js');
 const path = require('path');
+const remote = require('electron').remote;
 
 module.exports = {
   drawDendrogram: function(divId, data, descriptors, rootDir) {

--- a/js/modules/preview.js
+++ b/js/modules/preview.js
@@ -14,8 +14,8 @@ module.exports = {
 	imagePreview: function(labels){
 		/* CONFIG */
 
-			xOffset = 10;
-			yOffset = 30;
+                       const xOffset = 10;
+                       const yOffset = 30;
 
 			// these 2 variable determine popup's distance from the cursor
 			// you might want to adjust to get the right result

--- a/js/modules/properties.js
+++ b/js/modules/properties.js
@@ -1,5 +1,7 @@
 const Tokenfield = require('tokenfield');
 const remote = require('electron').remote;
+const path = require('path');
+const modal = require('./modal.js');
 
 var activeNode = undefined;
 var descriptors = undefined;
@@ -161,6 +163,7 @@ module.exports = {
 
 function addPropsListener() {
   // Annotate cluster with tags
+  let tags = remote.getGlobal('shared').tags;
   const propsTagInput = document.querySelector('.tokenfield-input');
   propsTagInput.addEventListener("keydown", (event) => {
     // Number 13 is the "Enter" key on the keyboard


### PR DESCRIPTION
## Summary
- fix missing 'fs' import in Electron app startup
- fix missing `path` and modal imports in the properties module
- load tags from the `shared` object when adding tag listeners
- add remote import for dendrogram module
- define offsets with `const` in preview module

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad6fb180832bb8f7d5caa3b5282a